### PR TITLE
背景广告 两边支持其它类型素材

### DIFF
--- a/src/plus/BgMedia.js
+++ b/src/plus/BgMedia.js
@@ -15,27 +15,75 @@
         }
         //body 设置背景
         this.config = config;
+
         var body  = document.body;
+
         //如果之前的cssText不以;结尾，在IE8下 样式显示不正确。
-        body.style.cssText += ';background:url(' + config.src + ') no-repeat center ' + config.top + 'px;margin:0px;';
+        body.style.cssText += ';background:url(' + config.src[0] + ') no-repeat center ' + config.top + 'px;margin:0px;';
 
         midBg.style.cssText += ';position:relative;height: ' + config.headHeight + 'px;width: ' + config.midWidth + 'px;margin:0 auto;';
-        midBg.innerHTML = '<a href="' + config.link + '" target="_blank" style="display:block;height:' + config.headHeight + 'px;width: ' + config.midWidth + 'px;"></a>';
+        midBg.innerHTML = '<a href="' + config.link[0] + '" target="_blank" style="display:block;height:' + config.headHeight + 'px;width: ' + config.midWidth + 'px;"></a>';
 
-        if (config.asideClickable) {//该变量应该是只读的，应该有更好的写法
+        var  halfWidth = (config.width - config.midWidth) / 2;
+        var leftAd = this.leftAd = document.createElement('div');
+        leftAd.id = 'bgLeftAd';
+        leftAd.style.cssText += ';position: absolute;height: ' + config.height + 'px;width:' + halfWidth + 'px;left:0px;top: ' + config.top + 'px';
+        body.appendChild(leftAd);
+
+        var rightAd = this.rightAd = document.createElement('div');
+        rightAd.id = 'bgRightAd';
+        rightAd.style.cssText += ';position: absolute;height: ' + config.height + 'px;width:' + halfWidth + 'px;left:0px;top: ' + config.top + 'px';
+        body.appendChild(rightAd);
+
+        if (config.src[1]) { //左右两侧有广告内容
+            var type = config.type[1] || config.type[0],
+                src = config.src[1],
+                options = {};
+            //避免flash覆盖背景
+            if (type === 'flash' || /\.swf$/.test(src)) {
+                options = {wmode: 'transparent'};
+            }
+            leftAd.innerHTML = sinaadToolkit.ad.createHTML(
+                type,
+                src,
+                halfWidth,
+                config.height,
+                config.link[1] || config.link[0],
+                config.monitor,
+                undefined,
+                options
+            );
+
+            type = config.type[2] || config.type[1] || config.type[0],
+            src = config.src[2] || config.src[1];
+            options = {};
+            if (type === 'flash' || /\.swf$/.test(src)) {
+                options = {wmode: 'transparent'};
+            }
+
+            rightAd.innerHTML = sinaadToolkit.ad.createHTML(
+                type,
+                src,
+                halfWidth,
+                config.height,
+                config.link[2] || config.link[1] || config.link[0],
+                config.monitor,
+                undefined,
+                options
+            );
+        } else if (config.asideClickable) {//该变量应该是只读的，应该有更好的写法
             //左右可点击
-            var leftAd = this.leftAd = document.createElement('a');
-            leftAd.setAttribute('href', config.link);
-            leftAd.setAttribute('target', '_blank');
+            var clickLink = document.createElement('a');
+            clickLink.setAttribute('href', config.link[1] || config.link[0]);
+            clickLink.setAttribute('target', '_blank');
+            clickLink.style.cssText += ';display: block;height: ' + config.height + 'px;';
+            leftAd.appendChild(clickLink);
 
-            var rightAd =  this.rightAd = document.createElement('a');
-            rightAd.setAttribute('href', config.link);
-            rightAd.setAttribute('target', '_blank');
-
-            leftAd.style.cssText += ';position: absolute;height: ' + config.height + 'px;left:0px;top: ' + config.top + 'px';
-            rightAd.style.cssText += ';position: absolute;height: ' + config.height + 'px;left:0px;top: ' + config.top + 'px';
-            body.appendChild(leftAd);
-            body.appendChild(rightAd);
+            clickLink = document.createElement('a');
+            clickLink.setAttribute('href', config.link[2] || config.link[1] || config.link[0]);
+            clickLink.setAttribute('target', '_blank');
+            clickLink.style.cssText += ';display:block;height: ' + config.height + 'px;';
+            rightAd.appendChild(clickLink);
         }
         
 
@@ -46,7 +94,7 @@
         //初始调整大小
         this.getResizeHandler()();
 
-        this.closeHandler = this.getResizeHandler();
+        this.closeHandler = this.getResizeHandler(); //保存下来，为了解绑window上的事件
         sinaadToolkit.event.on(window, 'resize', this.closeHandler);
         sinaadToolkit.event.on(closeBtn, 'click', this.getCloseHandler());
     }
@@ -55,19 +103,12 @@
         getResizeHandler: function () {
             var me = this;
             return function () {
-                var clientWidth = document.body.clientWidth;
                 var midWidth = me.config.midWidth;
                 var midX = sinaadToolkit.dom.getPosition(document.getElementById('bgAdWrap')).left;
 
-                var halfWidth = (clientWidth - midWidth) / 2;
-                if (halfWidth < 0) {
-                    halfWidth = 0;
-                }
-
-                if (me.config.asideClickable) {
-                    me.leftAd.style.cssText += ';width:' + halfWidth + 'px;left: ' + (midX - halfWidth) + 'px';
-                    me.rightAd.style.cssText += ';width:' + halfWidth + 'px;left: ' + (midX + midWidth) + 'px';
-                }
+                var  halfWidth = (me.config.width - me.config.midWidth) / 2;
+                me.leftAd.style.left = (midX - halfWidth) + 'px';
+                me.rightAd.style.left = (midX + midWidth) + 'px';
             };
         },
         getCloseHandler: function () {

--- a/src/sinaads.js
+++ b/src/sinaads.js
@@ -1027,12 +1027,12 @@ var viewModule = (function () {
         content = content[0];
         var bgMediaData = {
             pdps : config.sinaads_ad_pdps,
-            src : content.src[0] || '',
-            type : content.type || '',
-            link : content.link[0] || '',
+            src : content.src,
+            type : content.type,
+            link : content.link,
             width : width || 1600,
             height : height || config.sinaads_bg_height,
-            midWidth : config.sinaads_bg_midWidth,
+            midWidth : config.sinaads_bg_midWidth || 1000,
             headHeight : config.sinaads_bg_headHeight || 30,
             top : config.sinaads_bg_top || 120,
             asideClickable: config.sinaads_bg_asideClick || true,

--- a/src/sinaads/view/bg.js
+++ b/src/sinaads/view/bg.js
@@ -4,9 +4,9 @@
         content = content[0];
         var bgMediaData = {
             pdps : config.sinaads_ad_pdps,
-            src : content.src[0] || '',
-            type : content.type || '',
-            link : content.link[0] || '',
+            src : content.src,
+            type : content.type,
+            link : content.link,
             width : width || 1600,
             height : height || config.sinaads_bg_height,
             midWidth : config.sinaads_bg_midWidth || 1000,

--- a/src/spec/lmt.js
+++ b/src/spec/lmt.js
@@ -1,0 +1,139 @@
+/**
+ * [从右边推出来的广告]
+ * @return {[type]} [description]
+ */
+(function(){
+    "use strict";
+    var mediaControl,
+        shiftList = ['.main', '.top-search-wrap'], //左侧需要移动的DOM
+        offsettop = 120,    //距顶部偏移量
+        doms = [],
+        ad_box;
+
+    var clientW = document.documentElement.clientWidth;
+    var oImg = new Image();
+    oImg.src = 'http://d1.sina.com.cn/shh/lechan/20140219sina/1000-600.swf';
+    function init(){
+        // var clientH = document.documentElement.clientHeight;
+        // ad_wrap.style.height = clientH+"px";
+        // ad_wrap.style.overflow = "hidden";
+        var i;
+        for (i = shiftList.length - 1; i >= 0; i--) {
+            doms = doms.concat(querySimpleSelector(shiftList[i]));
+        }
+        
+        for (i = doms.length - 1; i >= 0; i--) {
+            doms[i].style.position = 'relative';
+        }
+        ad_box = document.createElement('div');
+        document.body.appendChild(ad_box);
+        ad_box.style.cssText = 'width: 1000px; height: 600px; position: absolute; top: 46px; left:' + clientW + 'px; top:' + offsettop + 'px; display: block;';
+        play();
+    }
+    /**
+     * [querySimpleSelector 简单的选择器，仅支持#**id选择 .**类选择]
+     * @param  {[String]} sel [#选择或.选择]
+     * @return {[Array]}     [选择结果]
+     */
+    function querySimpleSelector (sel) {
+        var result = [];
+        if (sel[0] === '.') {
+            result = getElementsByClassName(document, sel.slice(1));
+        } else if (sel[0] === '#') {
+            result.push(document.getElementById(sel.slice(1)));
+        } else {
+            result.push(document.getElementById(sel));
+        }
+        return result;
+    }
+
+    function getElementsByClassName (node, classname) {
+        var a = [];
+        var re = new RegExp('(^| )'+classname+'( |$)');
+        var els = node.getElementsByTagName("*");
+        for(var i=0, j= els.length; i < j; i++) {
+            if(re.test(els[i].className)) {
+                a.push(els[i]);
+            }
+        }
+        return a;
+    }
+    function play () {
+        var i;
+        for (i = doms.length - 1; i >= 0; i--) {
+            startMove(doms[i], {"left": "-1000"});
+        }
+        startMove(ad_box,{"left":(clientW - 1000)});
+        getflash(ad_box,'http://d1.sina.com.cn/shh/lechan/20140219sina/1000-600.swf','fl1','1000','600','transparent');
+        setTimeout(function(){
+            end();
+        }, 10000);
+    }
+    function end() {
+        var i;
+        // startMove(ad_main,{"left":"0"});
+        for (i = doms.length - 1; i >= 0; i--) {
+            startMove(doms[i], {"left": "0"});
+        }
+        startMove(ad_box,{"left":clientW},function(){
+            ad_box.innerHTML = '';
+            // ad_wrap.style.height = "auto";
+            // ad_wrap.style.overflow = "visible"; 
+            ad_box.style.display = 'none';
+            try {
+                mediaControl.done(mediaControl.stream);
+            } catch(e) {}
+        });
+        
+    }
+    function getflash(container,src,id,w,h,wmode){
+        var flash_obj ='<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" id="'+ id +'" name="'+ id +'" width="'+ w +'" height="'+ h +'" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab"><param name="movie" value="'+ src +'" /><param name="quality" value="high" /><param name="bgcolor" value="#ffffff" /><param name="allowScriptAccess" value="always" /><param name="wmode" value="'+ wmode +'" /><embed src="'+ src +'" quality="high" bgcolor="#ffffff" width="'+ w +'" height="'+ h +'" id="'+ id +'" name="'+ id +'" align="middle" play="true" loop="true" quality="high" allowScriptAccess="always" type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/go/getflashplayer" wmode="'+ wmode +'"></embed></object>';
+        container.innerHTML = flash_obj;
+    }
+    function startMove(obj,json,endFn){
+        clearInterval(obj.timer);
+        obj.timer = setInterval(function(){
+            var bBtn = true;
+            for(var attr in json){
+                var iCur = 0;
+                if(attr === 'opacity'){
+                    if(Math.round(parseFloat(getStyle(obj,attr)) * 100) === 0){
+                        iCur = Math.round(parseFloat(getStyle(obj,attr)) * 100);
+                    } else{
+                        iCur = Math.round(parseFloat(getStyle(obj,attr)) * 100) || 100;
+                    }
+                } else{
+                    iCur = parseInt(getStyle(obj,attr), 10) || 0;
+                }
+                var iSpeed = (json[attr] - iCur)/8;
+                iSpeed = iSpeed >0 ? Math.ceil(iSpeed) : Math.floor(iSpeed);
+                if(iCur !== json[attr]){
+                    bBtn = false;
+                }
+                if(attr === 'opacity'){
+                    obj.style.filter = 'alpha(opacity=' +(iCur + iSpeed)+ ')';
+                    obj.style.opacity = (iCur + iSpeed)/100;
+                }
+                else{
+                    obj.style[attr] = iCur + iSpeed + 'px';
+                }
+            }
+            if(bBtn){
+                clearInterval(obj.timer);
+                if(endFn){
+                    endFn.call(obj);
+                }
+            }
+        },30);
+    }
+    
+    function getStyle(obj,attr){
+        if(obj.currentStyle){
+            return obj.currentStyle[attr];
+        }
+        else{
+            return getComputedStyle(obj,false)[attr];
+        }
+    }
+    init();
+})();


### PR DESCRIPTION
**背景广告两边支持其它素材类型广告**
view/bg.js   此次将src type link数组传入 BgMedia 之前只考虑一个素材，传入的是数组的第一个元素
plus/BgMedia.js 具体参数没变，左右如果有素材将填入素材广告。
当窗口缩放时，以中间为中心，两边隐藏。
如果两边是flash素材，设置透明不会覆盖背景。

**从右边推出的流媒体广告**
/spec/lmt.js 修改之前已有广告，将整个页面往左推出。为不影响页面dom，不给之前的加上wrapper。
shiftList 数组 表示页面往左推的文档节点，支持class和ID
offsettop 表示移入的广告距离顶部高度。
